### PR TITLE
Added query functionality to endpoint GET /api/articles

### DIFF
--- a/__tests__/integration.test.js
+++ b/__tests__/integration.test.js
@@ -91,6 +91,49 @@ describe("/api/articles", () => {
     })
   })
 
+  test("GET QUERY: Requests with a topic query should return an array of all articles with the matching topic ", () => {
+    return request(app)
+    .get("/api/articles?topic=cats")
+    .expect(200)
+    .then(({body})=>{
+      const {articles} = body
+      expect(articles.length).toBe(3)
+      expect(articles).toBeSortedBy("created_at", {descending: true})
+      articles.forEach(article => {
+        expect(article).toMatchObject({
+          article_id: expect.any(Number),
+          title: expect.any(String),
+          topic: "cats",
+          author: expect.any(String),
+          created_at: expect.any(String),
+          votes: expect.any(Number),
+          article_img_url:expect.any(String),
+          comment_count: expect.any(Number)
+        });
+      })
+    })
+  })
+
+  test("GET QUERY 404: When the query value doesn't exist in the database, should return status 404 with not found message", ()=>{
+    return request(app)
+    .get("/api/articles?topic=blackholes")
+    .expect(404)
+    .then(({body})=>{
+      const {msg} = body
+      expect(msg).toBe("Not found")
+    })
+  })
+
+  test("GET QUERY 400: When the query key is not on the greenlist, should return status 400 with bad request message", ()=>{
+    return request(app)
+    .get("/api/articles?backdoor=cats")
+    .expect(400)
+    .then(({body})=>{
+      const {msg} = body
+      expect(msg).toBe("Bad request")
+    })
+  })
+
 });
 
 // api/articles/:article_id

--- a/controllers/articles.js
+++ b/controllers/articles.js
@@ -3,7 +3,8 @@ const {findArticle, findArticles, updateArticle} = require('../models/articles')
 
 
 function getArticles(req,res,next) {
-  return findArticles().then((articles)=>{
+  const query = req.query
+  return findArticles(query).then((articles)=>{
     res.status(200).send({articles})
   })
   .catch((err)=>{

--- a/db/data/test-data/articles.js
+++ b/db/data/test-data/articles.js
@@ -74,7 +74,7 @@ module.exports = [
   },
   {
     title: "They're not exactly dogs, are they?",
-    topic: "mitch",
+    topic: "cats",
     author: "butter_bridge",
     body: "Well? Think about it.",
     created_at: 1591438200000,
@@ -92,7 +92,7 @@ module.exports = [
   },
   {
     title: "Am I a cat?",
-    topic: "mitch",
+    topic: "cats",
     author: "icellusedkars",
     body: "Having run out of ideas for articles, I am staring at the wall blankly, like a cat. Does this make me a cat?",
     created_at: 1579126860000,

--- a/endpoints.json
+++ b/endpoints.json
@@ -13,7 +13,7 @@
 
   "GET /api/articles": {
     "description": "serves an array of all articles, sorted by created_at in descending order",
-    "queries": [],
+    "queries": ["topic"],
     "exampleResponse": {
       "articles": [
         {


### PR DESCRIPTION
Added **query** functionality to endpoint **GET** **/api/articles**

> Files modified:
- controllers/articles (modified getArticles function)
- models/articles (modified findArticles function)
- endpoints.json (added query key to existing endpoint description)


> Tests created:
- GET QUERY successful
- GET QUERY 404
- GET QUERY 400

> Notes:

I also thought to test for an invalid query value, e.g. a number, but realised the input is always a string anyway. Also, a topic could feasibly be a number. So I removed this test as I think the existing 404 test covers this as well.

```
  test.only("GET QUERY 400: When the query value is of invalid type, should return status 400 with bad request message", ()=>{
    return request(app)
    .get("/api/articles?topic=1")
    .expect(400)
    .then(({body})=>{
      const {msg} = body
      expect(msg).toBe("Bad request")
    })
  })
```